### PR TITLE
Fix pluralize rules regex

### DIFF
--- a/src/string/pluralize.rs
+++ b/src/string/pluralize.rs
@@ -23,8 +23,8 @@ static RULES: Lazy<Vec<(Regex, &'static str)>> = Lazy::new(|| {
            (r"(\w*(x|ch|ss|sh|zz)es)$", ""),
            (r"(\w*(x|ch|ss|sh|zz))$", "es"),
            (r"(\w*(matr|cod|mur|sil|vert|ind|append))(?:ix|ex)$", "ices"),
-           (r"(\w*(m|l)(?:ice|ouse))$", "ice"),
-           (r"(\w*(pe)(?:rson|ople))$", "ople"),
+           (r"(\w*(m|l))(?:ice|ouse)$", "ice"),
+           (r"(\w*(pe))(?:rson|ople)$", "ople"),
            (r"(\w*(child))(?:ren)?$", "ren"),
            (r"(\w*eaux)$", "")].into_iter().map(|(rule, replace)| {(Regex::new(rule).unwrap(), replace)}).collect()
 });
@@ -168,6 +168,8 @@ mod tests {
         knife => knives;
         agendum => agenda;
         elf => elves;
-        zoology => zoology
+        zoology => zoology;
+        mice => mice;
+        people => people
     }
 }


### PR DESCRIPTION
# What it does:

Properly pluralizes `mice`, `lice` and `people`

Without this fix, those words are wrongly pluralized:

```
---- string::pluralize::tests::mice stdout ----
thread 'string::pluralize::tests::mice' panicked at 'assertion failed: `(left == right)`
  left: `"mice"`,
 right: `"miceice"`', src/string/pluralize.rs:162:5

---- string::pluralize::tests::people stdout ----
thread 'string::pluralize::tests::people' panicked at 'assertion failed: `(left == right)`
  left: `"people"`,
 right: `"peopleople"`', src/string/pluralize.rs:162:5
```

# Why it does it:

By fixing the pluralize rules regex 

# Related issues:

None