### PR TITLE
fix: add legislation to exceptions

### DIFF
--- a/src/string/pluralize.rs
+++ b/src/string/pluralize.rs
@@ -109,6 +109,7 @@ pub fn to_plural(non_plural_string: &str) -> String {
             "ox" => "oxen",
             "man" => "men",
             "woman" => "women",
+            "legislation" => "legislation",
             "die" => "dice",
             "yes" => "yeses",
             "foot" => "feet",

--- a/src/string/pluralize.rs
+++ b/src/string/pluralize.rs
@@ -119,10 +119,10 @@ pub fn to_plural(non_plural_string: &str) -> String {
             "quiz" => "quizzes"
         ];
         for &(ref rule, replace) in RULES.iter().rev() {
-            if let Some(c) = rule.captures(non_plural_string) {
-                if let Some(c) = c.get(1) {
-                    return format!("{}{}", c.as_str(), replace);
-                }
+            if let Some(c) = rule.captures(non_plural_string)
+                && let Some(c) = c.get(1)
+            {
+                return format!("{}{}", c.as_str(), replace);
             }
         }
 

--- a/src/string/singularize.rs
+++ b/src/string/singularize.rs
@@ -94,12 +94,12 @@ pub fn to_singular(non_singular_string: &str) -> String {
             "quizzes" => "quiz"
         ];
         for &(ref rule, replace) in RULES.iter().rev() {
-            if let Some(captures) = rule.captures(non_singular_string) {
-                if let Some(c) = captures.get(1) {
-                    let mut buf = String::new();
-                    captures.expand(&format!("{}{}", c.as_str(), replace), &mut buf);
-                    return buf;
-                }
+            if let Some(captures) = rule.captures(non_singular_string)
+                && let Some(c) = captures.get(1)
+            {
+                let mut buf = String::new();
+                captures.expand(&format!("{}{}", c.as_str(), replace), &mut buf);
+                return buf;
             }
         }
 

--- a/src/string/singularize.rs
+++ b/src/string/singularize.rs
@@ -84,6 +84,7 @@ pub fn to_singular(non_singular_string: &str) -> String {
             "boxes" => "box",
             "men" => "man",
             "women" => "woman",
+            "legislation" => "legislation",
             "dice" => "die",
             "yeses" => "yes",
             "feet" => "foot",


### PR DESCRIPTION
# What it does:
Adds an exception for legislation. Legislation is an uncountable noun.

Fixed the `clippy::collapsable_if_let` lint

# Why it does it:
Could be good for it

# Related issues