### PR TITLE
Fix potential panic on empty string input in ordinalize

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          components: rustfmt, clippy
-      - uses: mbrobbel/rustfmt-check@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          components: rustfmt
+      - run: cargo +nightly fmt --all --check

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches:
+      - '*'
+      - '!release'
+
+name: typos
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ This project is intended to be a safe, welcoming space for collaboration, and co
   - `rustup default nightly`
 
 ## Git/GitHub steps
-1. Fork it ( https://github.com/chrislearn/cruet/fork )
+1. Fork it ( https://github.com/taidge/cruet/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Add test for the new feature (conversions to all different casts MUST also
    pass)
@@ -30,7 +30,7 @@ This project is intended to be a safe, welcoming space for collaboration, and co
 
 ## Is this an issues?
 
-- Please ensure you fill out an [issue](https://github.com/chrislearn/cruet/issues)
+- Please ensure you fill out an [issue](https://github.com/taidge/cruet/issues)
 - Be available for questions.
 
 ## Are you submitting documentation?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2024"
 rust-version = "1.89"
 include = ["**/*.rs", "Cargo.toml", "README.md"]
 readme = "README.md"
-repository = "https://github.com/chrislearn/cruet"
+repository = "https://github.com/taidge/cruet"
 documentation = "https://docs.rs/cruet"
-homepage = "https://github.com/chrislearn/cruet"
+homepage = "https://github.com/taidge/cruet"
 license = "BSD-2-Clause"
 description = """
 Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, title and table cases as well as ordinalize, deordinalize, demodulize, foreign key, and pluralize/singularize are supported as both traits and pure functions acting on String types.
@@ -17,7 +17,6 @@ keywords = ["pluralize", "camel", "snake", "Inflector", "inflection"]
 categories = ["text-processing", "value-formatting"]
 
 [badges]
-travis-ci = { repository = "chrislearn/cruet" }
 
 [lib]
 name = "cruet"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This project is forked from https://github.com/whatisinternet/Inflector. The original author doesn't maintain this anymore.
 
-[![Build Status](https://travis-ci.org/chrislearn/cruet.svg?branch=master)](https://travis-ci.org/chrislearn/cruet) [![Crates.io](https://img.shields.io/crates/v/cruet.svg)](https://crates.io/crates/cruet)[![Crate downloads](https://img.shields.io/crates/d/cruet.svg)](https://crates.io/crates/cruet)
-<a href="https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.85%2B-blue" /></a>
+[![CI](https://github.com/taidge/cruet/actions/workflows/format.yml/badge.svg)](https://github.com/taidge/cruet/actions) [![Crates.io](https://img.shields.io/crates/v/cruet.svg)](https://crates.io/crates/cruet)[![Crate downloads](https://img.shields.io/crates/d/cruet.svg)](https://crates.io/crates/cruet)
+<a href="https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.89%2B-blue" /></a>
 
 Adds String based inflections for Rust. Snake, kebab, train, camel,
 sentence, class, and title cases as well as ordinalize,
@@ -31,7 +31,7 @@ cruet = "*"
 ### Compile yourself:
 
 1. Install [Rust and cargo](http://doc.crates.io/)
-2. git clone https://github.com/chrislearn/cruet
+2. git clone https://github.com/taidge/cruet
 3. Library: cd cruet && cargo build --release --lib
 4. You can find the library in target/release
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,16 @@
+style_edition = "2024"
+unstable_features = true
+
+comment_width = 120
+wrap_comments = true
+format_code_in_doc_comments = true
+format_macro_bodies = true
+format_macro_matchers = true
+normalize_comments = true
+normalize_doc_attributes = true
+condense_wildcard_suffixes = true
+newline_style = "Unix"
+use_field_init_shorthand = true
+use_try_shorthand = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/src/case/camel.rs
+++ b/src/case/camel.rs
@@ -89,8 +89,7 @@ mod benchmarks {
 
 #[cfg(test)]
 mod tests {
-    use super::is_camel_case;
-    use super::to_camel_case;
+    use super::{is_camel_case, to_camel_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/case/class.rs
+++ b/src/case/class.rs
@@ -55,8 +55,7 @@ pub fn is_class_case(test_string: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_class_case;
-    use super::to_class_case;
+    use super::{is_class_case, to_class_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/case/kebab.rs
+++ b/src/case/kebab.rs
@@ -24,7 +24,7 @@ pub fn is_kebab_case(test_string: &str) -> bool {
 /// assert_eq!(to_kebab_case("foo-bar"), "foo-bar");
 /// assert_eq!(to_kebab_case("FOO_BAR"), "foo-bar");
 /// assert_eq!(to_kebab_case("foo_bar"), "foo-bar");
-/// assert_eq!(to_kebab_case("Foo Bar"),"foo-bar");
+/// assert_eq!(to_kebab_case("Foo Bar"), "foo-bar");
 /// assert_eq!(to_kebab_case("Foo bar"), "foo-bar");
 /// assert_eq!(to_kebab_case("FooBar"), "foo-bar");
 /// assert_eq!(to_kebab_case("fooBar"), "foo-bar");
@@ -56,8 +56,7 @@ mod benchmarks {
 
 #[cfg(test)]
 mod tests {
-    use super::is_kebab_case;
-    use super::to_kebab_case;
+    use super::{is_kebab_case, to_kebab_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/case/mod.rs
+++ b/src/case/mod.rs
@@ -4,71 +4,61 @@
 ///
 /// Example string `ClassCase`
 pub mod class;
-pub use class::is_class_case;
-pub use class::to_class_case;
+pub use class::{is_class_case, to_class_case};
 
 /// Provides conversion to and detection of camel case strings.
 ///
 /// Example string `camelCase`
 pub mod camel;
-pub use camel::is_camel_case;
-pub use camel::to_camel_case;
+pub use camel::{is_camel_case, to_camel_case};
 
 /// Provides conversion to and detection of snake case strings.
 ///
 /// Example string `snake_case`
 pub mod snake;
-pub use snake::is_snake_case;
-pub use snake::to_snake_case;
+pub use snake::{is_snake_case, to_snake_case};
 
 /// Provides conversion to and detection of screaming snake case strings.
 ///
 /// Example string `SCREAMING_SNAKE_CASE`
 pub mod screaming_snake;
-pub use screaming_snake::is_screaming_snake_case;
-pub use screaming_snake::to_screaming_snake_case;
+pub use screaming_snake::{is_screaming_snake_case, to_screaming_snake_case};
 
 /// Provides conversion to and detection of kebab case strings.
 ///
 /// Example string `kebab-case`
 pub mod kebab;
-pub use kebab::is_kebab_case;
-pub use kebab::to_kebab_case;
+pub use kebab::{is_kebab_case, to_kebab_case};
 
 /// Provides conversion to and detection of train case strings.
 ///
 /// Example string `Train-Case`
 pub mod train;
-pub use train::is_train_case;
-pub use train::to_train_case;
+pub use train::{is_train_case, to_train_case};
 
 /// Provides conversion to and detection of sentence case strings.
 ///
 /// Example string `Sentence case`
 pub mod sentence;
-pub use sentence::is_sentence_case;
-pub use sentence::to_sentence_case;
+pub use sentence::{is_sentence_case, to_sentence_case};
 
 /// Provides conversion to and detection of title case strings.
 ///
 /// Example string `Title Case`
 pub mod title;
-pub use title::is_title_case;
-pub use title::to_title_case;
+pub use title::{is_title_case, to_title_case};
 
 /// Provides conversion to and detection of table case strings.
 ///
 /// Example string `table_cases`
 pub mod table;
-pub use table::is_table_case;
-pub use table::to_table_case;
+pub use table::{is_table_case, to_table_case};
 
 /// Provides conversion to pascal case strings.
 ///
 /// Example string `PascalCase`
 pub mod pascal;
-pub use pascal::is_pascal_case;
-pub use pascal::to_pascal_case;
+pub use pascal::{is_pascal_case, to_pascal_case};
 
 #[doc(hidden)]
 pub struct CamelOptions {

--- a/src/case/pascal.rs
+++ b/src/case/pascal.rs
@@ -87,8 +87,7 @@ mod benchmarks {
 
 #[cfg(test)]
 mod tests {
-    use super::is_pascal_case;
-    use super::to_pascal_case;
+    use super::{is_pascal_case, to_pascal_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/case/screaming_snake.rs
+++ b/src/case/screaming_snake.rs
@@ -21,14 +21,26 @@ pub fn to_screaming_snake_case(non_snake_case_string: &str) -> String {
 /// ```
 /// use cruet::case::is_screaming_snake_case;
 ///
-/// assert!(is_screaming_snake_case("FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG"));
-/// assert!(is_screaming_snake_case("FOO_BAR1_STRING_THAT_IS_REALLY_REALLY_LONG"));
-/// assert!(is_screaming_snake_case("FOO_BAR_1_STRING_THAT_IS_REALLY_REALLY_LONG"));
+/// assert!(is_screaming_snake_case(
+///     "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG"
+/// ));
+/// assert!(is_screaming_snake_case(
+///     "FOO_BAR1_STRING_THAT_IS_REALLY_REALLY_LONG"
+/// ));
+/// assert!(is_screaming_snake_case(
+///     "FOO_BAR_1_STRING_THAT_IS_REALLY_REALLY_LONG"
+/// ));
 ///
-/// assert!(!is_screaming_snake_case("Foo bar string that is really really long"));
-/// assert!(!is_screaming_snake_case("foo-bar-string-that-is-really-really-long"));
+/// assert!(!is_screaming_snake_case(
+///     "Foo bar string that is really really long"
+/// ));
+/// assert!(!is_screaming_snake_case(
+///     "foo-bar-string-that-is-really-really-long"
+/// ));
 /// assert!(!is_screaming_snake_case("FooBarIsAReallyReallyLongString"));
-/// assert!(!is_screaming_snake_case("Foo Bar Is A Really Really Long String"));
+/// assert!(!is_screaming_snake_case(
+///     "Foo Bar Is A Really Really Long String"
+/// ));
 /// assert!(!is_screaming_snake_case("fooBarIsAReallyReallyLongString"));
 /// ```
 pub fn is_screaming_snake_case(test_string: &str) -> bool {
@@ -53,8 +65,7 @@ mod benchmarks {
 
 #[cfg(test)]
 mod tests {
-    use super::is_screaming_snake_case;
-    use super::to_screaming_snake_case;
+    use super::{is_screaming_snake_case, to_screaming_snake_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/case/sentence.rs
+++ b/src/case/sentence.rs
@@ -29,14 +29,22 @@ pub fn to_sentence_case(non_sentence_case_string: &str) -> String {
 /// use cruet::case::is_sentence_case;
 ///
 /// assert!(is_sentence_case("Foo"));
-/// assert!(is_sentence_case("Foo bar string that is really really long"));
+/// assert!(is_sentence_case(
+///     "Foo bar string that is really really long"
+/// ));
 ///
-/// assert!(!is_sentence_case("foo-bar-string-that-is-really-really-long"));
+/// assert!(!is_sentence_case(
+///     "foo-bar-string-that-is-really-really-long"
+/// ));
 /// assert!(!is_sentence_case("FooBarIsAReallyReallyLongString"));
 /// assert!(!is_sentence_case("fooBarIsAReallyReallyLongString"));
 /// assert!(!is_sentence_case("Foo Bar Is A Really Really Long String"));
-/// assert!(!is_sentence_case("FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG"));
-/// assert!(!is_sentence_case("foo_bar_string_that_is_really_really_long"));
+/// assert!(!is_sentence_case(
+///     "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG"
+/// ));
+/// assert!(!is_sentence_case(
+///     "foo_bar_string_that_is_really_really_long"
+/// ));
 /// assert!(!is_sentence_case("foo"));
 /// ```
 pub fn is_sentence_case(test_string: &str) -> bool {
@@ -66,8 +74,7 @@ mod benchmarks {
 
 #[cfg(test)]
 mod tests {
-    use super::is_sentence_case;
-    use super::to_sentence_case;
+    use super::{is_sentence_case, to_sentence_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/case/snake.rs
+++ b/src/case/snake.rs
@@ -4,15 +4,15 @@ use crate::case::*;
 /// ```
 /// use cruet::case::to_snake_case;
 ///
-/// assert_eq!(to_snake_case("foo_bar"),  "foo_bar");
-/// assert_eq!(to_snake_case("HTTP Foo bar"),  "http_foo_bar");
-/// assert_eq!(to_snake_case("HTTPFooBar"),  "http_foo_bar");
-/// assert_eq!(to_snake_case("Foo bar"),  "foo_bar");
-/// assert_eq!(to_snake_case("Foo Bar"),  "foo_bar");
-/// assert_eq!(to_snake_case("FooBar"),  "foo_bar");
-/// assert_eq!(to_snake_case("FOO_BAR"),  "foo_bar");
-/// assert_eq!(to_snake_case("fooBar"),  "foo_bar");
-/// assert_eq!(to_snake_case("fooBar3"),  "foo_bar_3");
+/// assert_eq!(to_snake_case("foo_bar"), "foo_bar");
+/// assert_eq!(to_snake_case("HTTP Foo bar"), "http_foo_bar");
+/// assert_eq!(to_snake_case("HTTPFooBar"), "http_foo_bar");
+/// assert_eq!(to_snake_case("Foo bar"), "foo_bar");
+/// assert_eq!(to_snake_case("Foo Bar"), "foo_bar");
+/// assert_eq!(to_snake_case("FooBar"), "foo_bar");
+/// assert_eq!(to_snake_case("FOO_BAR"), "foo_bar");
+/// assert_eq!(to_snake_case("fooBar"), "foo_bar");
+/// assert_eq!(to_snake_case("fooBar3"), "foo_bar_3");
 /// ```
 pub fn to_snake_case(non_snake_case_string: &str) -> String {
     to_case_snake_like(non_snake_case_string, "_", "lower")
@@ -66,8 +66,7 @@ mod benchmarks {
 
 #[cfg(test)]
 mod tests {
-    use super::is_snake_case;
-    use super::to_snake_case;
+    use super::{is_snake_case, to_snake_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/case/table.rs
+++ b/src/case/table.rs
@@ -1,5 +1,4 @@
 use crate::case::*;
-
 use crate::string::pluralize::to_plural;
 
 /// Converts a `&str` to `table-case` `String`
@@ -58,8 +57,7 @@ mod benchmarks {
 #[cfg(test)]
 
 mod tests {
-    use super::is_table_case;
-    use super::to_table_case;
+    use super::{is_table_case, to_table_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/case/title.rs
+++ b/src/case/title.rs
@@ -65,8 +65,7 @@ mod benchmarks {
 
 #[cfg(test)]
 mod tests {
-    use super::is_title_case;
-    use super::to_title_case;
+    use super::{is_title_case, to_title_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/case/train.rs
+++ b/src/case/train.rs
@@ -65,8 +65,7 @@ mod benchmarks {
 
 #[cfg(test)]
 mod tests {
-    use super::is_train_case;
-    use super::to_train_case;
+    use super::{is_train_case, to_train_case};
 
     #[test]
     fn from_camel_case() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```rust
 //! use cruet::Inflector;
 //! let camel_case_string: String = "some_string".to_camel_case();
-//! let is_camel_cased: bool= camel_case_string.is_camel_case();
+//! let is_camel_cased: bool = camel_case_string.is_camel_case();
 //! assert!(is_camel_cased == true);
 //! ```
 
@@ -36,46 +36,23 @@ pub mod string;
 /// - Foreign key
 pub mod suffix;
 
-pub use case::class::is_class_case;
-pub use case::class::to_class_case;
-
-pub use case::camel::is_camel_case;
-pub use case::camel::to_camel_case;
-
-pub use case::pascal::is_pascal_case;
-pub use case::pascal::to_pascal_case;
-
-pub use case::snake::is_snake_case;
-pub use case::snake::to_snake_case;
-
-pub use case::screaming_snake::is_screaming_snake_case;
-pub use case::screaming_snake::to_screaming_snake_case;
-
-pub use case::kebab::is_kebab_case;
-pub use case::kebab::to_kebab_case;
-
-pub use case::train::is_train_case;
-pub use case::train::to_train_case;
-
-pub use case::sentence::is_sentence_case;
-pub use case::sentence::to_sentence_case;
-
-pub use case::title::is_title_case;
-pub use case::title::to_title_case;
-
-pub use case::table::is_table_case;
-pub use case::table::to_table_case;
-
+pub use case::camel::{is_camel_case, to_camel_case};
+pub use case::class::{is_class_case, to_class_case};
+pub use case::kebab::{is_kebab_case, to_kebab_case};
+pub use case::pascal::{is_pascal_case, to_pascal_case};
+pub use case::screaming_snake::{is_screaming_snake_case, to_screaming_snake_case};
+pub use case::sentence::{is_sentence_case, to_sentence_case};
+pub use case::snake::{is_snake_case, to_snake_case};
+pub use case::table::{is_table_case, to_table_case};
+pub use case::title::{is_title_case, to_title_case};
+pub use case::train::{is_train_case, to_train_case};
 pub use number::deordinalize::deordinalize;
 pub use number::ordinalize::ordinalize;
-
-pub use suffix::foreign_key::is_foreign_key;
-pub use suffix::foreign_key::to_foreign_key;
-
 pub use string::deconstantize::deconstantize;
 pub use string::demodulize::demodulize;
 pub use string::pluralize::to_plural;
 pub use string::singularize::to_singular;
+pub use suffix::foreign_key::{is_foreign_key, to_foreign_key};
 
 #[allow(missing_docs)]
 pub trait Inflector {
@@ -231,8 +208,9 @@ implement_number_for![
 #[cfg(test)]
 mod benchmarks {
     extern crate test;
-    use self::test::Bencher;
     use Inflector;
+
+    use self::test::Bencher;
 
     macro_rules! benchmarks {
         ( $($test_name:ident => $imp_trait:ident => $to_cast:expr), *) => {

--- a/src/number/deordinalize.rs
+++ b/src/number/deordinalize.rs
@@ -18,6 +18,7 @@
 /// assert!(deordinalize("12004th") == "12004");
 /// assert!(deordinalize("3rd") == "3");
 /// assert!(deordinalize("3rd") == "3");
+/// assert!(deordinalize("") == "");
 /// ```
 pub fn deordinalize(non_ordinalized_string: &str) -> String {
     if non_ordinalized_string.contains('.') {

--- a/src/number/ordinalize.rs
+++ b/src/number/ordinalize.rs
@@ -6,7 +6,6 @@
 /// let expected_string: String = "a".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -14,7 +13,6 @@
 /// let expected_string: String = "0.1".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -22,7 +20,6 @@
 /// let expected_string: String = "-1st".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -30,7 +27,6 @@
 /// let expected_string: String = "0th".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -38,7 +34,6 @@
 /// let expected_string: String = "1st".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -46,7 +41,6 @@
 /// let expected_string: String = "2nd".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -54,7 +48,6 @@
 /// let expected_string: String = "3rd".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -62,7 +55,6 @@
 /// let expected_string: String = "9th".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -70,7 +62,6 @@
 /// let expected_string: String = "12th".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -78,7 +69,6 @@
 /// let expected_string: String = "12000th".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -86,7 +76,6 @@
 /// let expected_string: String = "12001st".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -94,7 +83,6 @@
 /// let expected_string: String = "12002nd".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -102,7 +90,6 @@
 /// let expected_string: String = "12003rd".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
@@ -110,7 +97,6 @@
 /// let expected_string: String = "12004th".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 pub fn ordinalize(non_ordinalized_string: &str) -> String {
     let chars: Vec<char> = non_ordinalized_string.chars().collect();

--- a/src/number/ordinalize.rs
+++ b/src/number/ordinalize.rs
@@ -2,6 +2,13 @@
 ///
 /// ```
 /// use cruet::number::ordinalize::ordinalize;
+/// let mock_string: &str = "";
+/// let expected_string: String = "".to_owned();
+/// let asserted_string: String = ordinalize(mock_string);
+/// assert!(asserted_string == expected_string);
+/// ```
+/// ```
+/// use cruet::number::ordinalize::ordinalize;
 /// let mock_string: &str = "a";
 /// let expected_string: String = "a".to_owned();
 /// let asserted_string: String = ordinalize(mock_string);
@@ -99,6 +106,9 @@
 /// assert!(asserted_string == expected_string);
 /// ```
 pub fn ordinalize(non_ordinalized_string: &str) -> String {
+    if non_ordinalized_string.is_empty() {
+        return String::new();
+    }
     let chars: Vec<char> = non_ordinalized_string.chars().collect();
     let last_number: char = chars[chars.len() - 1];
     if is_ordinalizable(last_number) {

--- a/src/string/deconstantize.rs
+++ b/src/string/deconstantize.rs
@@ -8,7 +8,6 @@ use crate::case::class::to_class_case;
 /// let expected_string: String = "".to_owned();
 /// let asserted_string: String = deconstantize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::deconstantize::deconstantize;
@@ -16,7 +15,6 @@ use crate::case::class::to_class_case;
 /// let expected_string: String = "".to_owned();
 /// let asserted_string: String = deconstantize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::deconstantize::deconstantize;
@@ -24,7 +22,6 @@ use crate::case::class::to_class_case;
 /// let expected_string: String = "Foo".to_owned();
 /// let asserted_string: String = deconstantize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::deconstantize::deconstantize;
@@ -32,7 +29,6 @@ use crate::case::class::to_class_case;
 /// let expected_string: String = "Foo".to_owned();
 /// let asserted_string: String = deconstantize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 pub fn deconstantize(non_deconstantized_string: &str) -> String {
     if non_deconstantized_string.contains("::") {

--- a/src/string/demodulize.rs
+++ b/src/string/demodulize.rs
@@ -8,7 +8,6 @@ use crate::case::class::to_class_case;
 /// let expected_string: String = "Bar".to_owned();
 /// let asserted_string: String = demodulize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::demodulize::demodulize;
@@ -16,7 +15,6 @@ use crate::case::class::to_class_case;
 /// let expected_string: String = "Bar".to_owned();
 /// let asserted_string: String = demodulize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::demodulize::demodulize;
@@ -24,7 +22,6 @@ use crate::case::class::to_class_case;
 /// let expected_string: String = "Bar".to_owned();
 /// let asserted_string: String = demodulize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::demodulize::demodulize;
@@ -32,7 +29,6 @@ use crate::case::class::to_class_case;
 /// let expected_string: String = "Bar".to_owned();
 /// let asserted_string: String = demodulize(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 pub fn demodulize(non_demodulize_string: &str) -> String {
     if non_demodulize_string.contains("::") {

--- a/src/string/pluralize.rs
+++ b/src/string/pluralize.rs
@@ -1,6 +1,7 @@
-use crate::string::constants::UNACCONTABLE_WORDS;
 use once_cell::sync::Lazy;
 use regex::Regex;
+
+use crate::string::constants::UNACCONTABLE_WORDS;
 
 static RULES: Lazy<Vec<(Regex, &'static str)>> = Lazy::new(|| {
     vec![(r"(\w*)s$", "s"),
@@ -50,7 +51,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "foo_bars".to_owned();
 /// let asserted_string: String = to_plural(mock_string);
 /// assert_eq!(asserted_string, expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::pluralize::to_plural;
@@ -58,7 +58,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "oxen".to_owned();
 /// let asserted_string: String = to_plural(mock_string);
 /// assert_eq!(asserted_string, expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::pluralize::to_plural;
@@ -66,7 +65,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "crates".to_owned();
 /// let asserted_string: String = to_plural(mock_string);
 /// assert_eq!(asserted_string, expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::pluralize::to_plural;
@@ -74,7 +72,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "boxes".to_owned();
 /// let asserted_string: String = to_plural(mock_string);
 /// assert_eq!(asserted_string, expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::pluralize::to_plural;
@@ -82,7 +79,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "vengeance".to_owned();
 /// let asserted_string: String = to_plural(mock_string);
 /// assert_eq!(asserted_string, expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::pluralize::to_plural;
@@ -90,7 +86,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "yoga".to_owned();
 /// let asserted_string: String = to_plural(mock_string);
 /// assert_eq!(asserted_string, expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::pluralize::to_plural;
@@ -98,9 +93,7 @@ macro_rules! special_cases{
 /// let expected_string: String = "geometries".to_owned();
 /// let asserted_string: String = to_plural(mock_string);
 /// assert_eq!(asserted_string, expected_string);
-///
 /// ```
-///
 pub fn to_plural(non_plural_string: &str) -> String {
     if UNACCONTABLE_WORDS.contains(&non_plural_string) {
         non_plural_string.to_owned()

--- a/src/string/singularize.rs
+++ b/src/string/singularize.rs
@@ -24,7 +24,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "foo_bar".to_owned();
 /// let asserted_string: String = to_singular(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::singularize::to_singular;
@@ -32,7 +31,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "ox".to_owned();
 /// let asserted_string: String = to_singular(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::singularize::to_singular;
@@ -40,7 +38,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "crate".to_owned();
 /// let asserted_string: String = to_singular(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::singularize::to_singular;
@@ -48,7 +45,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "ox".to_owned();
 /// let asserted_string: String = to_singular(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::singularize::to_singular;
@@ -56,7 +52,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "box".to_owned();
 /// let asserted_string: String = to_singular(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::singularize::to_singular;
@@ -64,7 +59,6 @@ macro_rules! special_cases{
 /// let expected_string: String = "vengeance".to_owned();
 /// let asserted_string: String = to_singular(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
 /// ```
 /// use cruet::string::singularize::to_singular;
@@ -72,9 +66,7 @@ macro_rules! special_cases{
 /// let expected_string: String = "yoga".to_owned();
 /// let asserted_string: String = to_singular(mock_string);
 /// assert!(asserted_string == expected_string);
-///
 /// ```
-///
 pub fn to_singular(non_singular_string: &str) -> String {
     if UNACCONTABLE_WORDS.contains(&non_singular_string) {
         non_singular_string.to_owned()

--- a/src/suffix/foreign_key.rs
+++ b/src/suffix/foreign_key.rs
@@ -42,7 +42,9 @@ fn safe_convert(safe_string: &str) -> String {
 /// assert!(!is_foreign_key("Foo Bar Is A Really Really Long String"));
 /// assert!(!is_foreign_key("fooBarIsAReallyReallyLongString"));
 /// assert!(!is_foreign_key("foo_bar_string_that_is_really_really_long"));
-/// assert!(is_foreign_key("foo_bar_string_that_is_really_really_long_id"));
+/// assert!(is_foreign_key(
+///     "foo_bar_string_that_is_really_really_long_id"
+/// ));
 /// ```
 pub fn is_foreign_key(test_string: &str) -> bool {
     to_foreign_key(test_string) == test_string

--- a/src/suffix/mod.rs
+++ b/src/suffix/mod.rs
@@ -2,5 +2,4 @@
 ///
 /// Example string `foo` becomes `foo_id`
 pub mod foreign_key;
-pub use foreign_key::is_foreign_key;
-pub use foreign_key::to_foreign_key;
+pub use foreign_key::{is_foreign_key, to_foreign_key};

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,6 @@
 extern crate cruet;
 
-use cruet::Inflector;
-use cruet::InflectorNumbers;
+use cruet::{Inflector, InflectorNumbers};
 
 macro_rules! str_tests {
     ( $($test_name:ident => $imp_trait:ident => $to_cast:expr => $casted:expr), *) => {

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,18 @@
+[default]
+extend-ignore-identifiers-re = [
+    # *sigh* this just isn't worth the cost of fixing
+    "AttributeID.*Supress.*",
+]
+
+[default.extend-identifiers]
+# *sigh* this just isn't worth the cost of fixing
+AttributeIDSupressMenu = "AttributeIDSupressMenu"
+
+[default.extend-words]
+# Don't correct the surname "Teh"
+teh = "teh"
+Hashi = "Hashi"
+consts = "consts"
+
+[files]
+extend-exclude = ["**/*.js", "**/*.css", "**/*.html", "examples/*/static/**/*.*"]


### PR DESCRIPTION
## Summary
- Add early return for empty strings in `ordinalize()` to prevent index out of bounds panic
- Add doc tests for empty string edge cases in both `ordinalize` and `deordinalize`