### PR TITLE
Replace once_cell with std::sync::LazyLock and deduplicate macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,8 @@ Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, ti
 keywords = ["pluralize", "camel", "snake", "Inflector", "inflection"]
 categories = ["text-processing", "value-formatting"]
 
-[badges]
-
 [lib]
 name = "cruet"
 
 [dependencies]
 regex = { version = "1" }
-once_cell = { version = "1" }

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,3 +1,16 @@
+macro_rules! special_cases {
+    ($s:ident, $($singular:expr => $plural:expr),*) => {
+        match &$s[..] {
+            $(
+                $singular => {
+                    return $plural.to_owned();
+                },
+            )*
+            _ => ()
+        }
+    }
+}
+
 /// Provides deconstantize a string.
 ///
 /// Example string `Foo::Bar` becomes `Foo`

--- a/src/string/pluralize.rs
+++ b/src/string/pluralize.rs
@@ -1,9 +1,10 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 use crate::string::constants::UNCOUNTABLE_WORDS;
 
-static RULES: Lazy<Vec<(Regex, &'static str)>> = Lazy::new(|| {
+static RULES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
     vec![(r"(\w*)s$", "s"),
            (r"(\w*([^aeiou]ese))$", ""),
            (r"(\w*(ax|test))is$", "es"),
@@ -29,19 +30,6 @@ static RULES: Lazy<Vec<(Regex, &'static str)>> = Lazy::new(|| {
            (r"(\w*(child))(?:ren)?$", "ren"),
            (r"(\w*eaux)$", "")].into_iter().map(|(rule, replace)| {(Regex::new(rule).unwrap(), replace)}).collect()
 });
-
-macro_rules! special_cases{
-    ($s:ident, $($singular: expr => $plural:expr), *) => {
-        match &$s[..] {
-            $(
-                $singular => {
-                    return $plural.to_owned();
-                },
-            )*
-            _ => ()
-        }
-    }
-}
 
 /// Converts a `&str` to pluralized `String`
 ///

--- a/src/string/singularize.rs
+++ b/src/string/singularize.rs
@@ -1,20 +1,8 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 use crate::string::constants::UNCOUNTABLE_WORDS;
-
-macro_rules! special_cases{
-    ($s:ident, $($singular: expr => $plural:expr), *) => {
-        match &$s[..] {
-            $(
-                $singular => {
-                    return $plural.to_owned();
-                },
-            )*
-            _ => ()
-        }
-    }
-}
 
 /// Converts a `&str` to singularized `String`
 ///
@@ -96,7 +84,7 @@ pub fn to_singular(non_singular_string: &str) -> String {
     }
 }
 
-static RULES: Lazy<Vec<(Regex, &'static str)>> = Lazy::new(|| {
+static RULES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
     vec![
         (r"(\w*)s$", ""),
         (r"(\w*(ss))$", ""),


### PR DESCRIPTION
## Summary
- Migrate from `once_cell::sync::Lazy` to `std::sync::LazyLock` (stable since Rust 1.80, MSRV is 1.89)
- Remove `once_cell` dependency from Cargo.toml
- Extract duplicate `special_cases!` macro to `string/mod.rs`
- Remove empty `[badges]` section from Cargo.toml