### PR TITLE
Fix pluralize/singularize losing prefix with hyphen or underscore

### DIFF
--- a/src/string/pluralize.rs
+++ b/src/string/pluralize.rs
@@ -83,6 +83,16 @@ static RULES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
 /// assert_eq!(asserted_string, expected_string);
 /// ```
 pub fn to_plural(non_plural_string: &str) -> String {
+    // Find the last separator (hyphen or underscore) to preserve prefixes
+    if let Some(pos) = non_plural_string.rfind(|c| c == '-' || c == '_') {
+        let prefix = &non_plural_string[..=pos]; // includes the separator
+        let last_word = &non_plural_string[pos + 1..];
+        if last_word.is_empty() {
+            return non_plural_string.to_owned();
+        }
+        return format!("{}{}", prefix, to_plural(last_word));
+    }
+
     if UNCOUNTABLE_WORDS.contains(&non_plural_string) {
         non_plural_string.to_owned()
     } else {
@@ -152,5 +162,15 @@ mod tests {
         zoology => zoology;
         mice => mice;
         people => people
+    }
+
+    #[test]
+    fn pluralize_kebab_case() {
+        assert_eq!("section-difficulties", super::to_plural("section-difficulty"));
+    }
+
+    #[test]
+    fn pluralize_snake_case_compound() {
+        assert_eq!("section_difficulties", super::to_plural("section_difficulty"));
     }
 }

--- a/src/string/singularize.rs
+++ b/src/string/singularize.rs
@@ -56,6 +56,16 @@ use crate::string::constants::UNCOUNTABLE_WORDS;
 /// assert!(asserted_string == expected_string);
 /// ```
 pub fn to_singular(non_singular_string: &str) -> String {
+    // Find the last separator (hyphen or underscore) to preserve prefixes
+    if let Some(pos) = non_singular_string.rfind(|c| c == '-' || c == '_') {
+        let prefix = &non_singular_string[..=pos]; // includes the separator
+        let last_word = &non_singular_string[pos + 1..];
+        if last_word.is_empty() {
+            return non_singular_string.to_owned();
+        }
+        return format!("{}{}", prefix, to_singular(last_word));
+    }
+
     if UNCOUNTABLE_WORDS.contains(&non_singular_string) {
         non_singular_string.to_owned()
     } else {
@@ -185,4 +195,14 @@ fn singularize_string_returns_none_option_if_no_match() {
     let asserted_string: String = to_singular("bacon");
 
     assert!(expected_string == asserted_string);
+}
+
+#[test]
+fn singularize_kebab_case() {
+    assert_eq!("section-difficulty", to_singular("section-difficulties"));
+}
+
+#[test]
+fn singularize_snake_case_compound() {
+    assert_eq!("section_difficulty", to_singular("section_difficulties"));
 }


### PR DESCRIPTION
## Summary
- `to_plural("section-difficulty")` was returning `"difficulties"` instead of `"section-difficulties"`
- Root cause: regex rules use `\w*` which doesn't match `-` or `_`, causing the prefix to be lost
- Fix: split on the last separator, pluralize/singularize only the last segment, then rejoin
- Same fix applied to both `to_plural` and `to_singular`

Fixes #5