### PR TITLE
Fix typos and use stable toolchain for CI fmt check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo +nightly fmt --all --check
+      - run: cargo fmt --all --check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - run: cargo +nightly fmt --all --check
+      - run: cargo fmt --all --check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - run: cargo fmt --all --check
+      - run: cargo +nightly fmt --all --check

--- a/src/case/camel.rs
+++ b/src/case/camel.rs
@@ -55,155 +55,155 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "fooBar".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "fooBar".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "fooBar".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "fooBar".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "fooBar".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "fooBar".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "fooBar".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "fooBar".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_case_with_loads_of_space() {
-        let convertable_string: String = "foo           bar".to_owned();
+        let convertible_string: String = "foo           bar".to_owned();
         let expected: String = "fooBar".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn a_name_with_a_dot() {
-        let convertable_string: String = "Robert C. Martin".to_owned();
+        let convertible_string: String = "Robert C. Martin".to_owned();
         let expected: String = "robertCMartin".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn random_text_with_bad_chars() {
-        let convertable_string: String = "Random text with *(bad) chars".to_owned();
+        let convertible_string: String = "Random text with *(bad) chars".to_owned();
         let expected: String = "randomTextWithBadChars".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn trailing_bad_chars() {
-        let convertable_string: String = "trailing bad_chars*(()())".to_owned();
+        let convertible_string: String = "trailing bad_chars*(()())".to_owned();
         let expected: String = "trailingBadChars".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn leading_bad_chars() {
-        let convertable_string: String = "-!#$%leading bad chars".to_owned();
+        let convertible_string: String = "-!#$%leading bad chars".to_owned();
         let expected: String = "leadingBadChars".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn wrapped_in_bad_chars() {
-        let convertable_string: String =
+        let convertible_string: String =
             "-!#$%wrapped in bad chars&*^*&(&*^&(<><?>><?><>))".to_owned();
         let expected: String = "wrappedInBadChars".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn has_a_sign() {
-        let convertable_string: String = "has a + sign".to_owned();
+        let convertible_string: String = "has a + sign".to_owned();
         let expected: String = "hasASign".to_owned();
-        assert_eq!(to_camel_case(&convertable_string), expected)
+        assert_eq!(to_camel_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_camel_case(&convertable_string), true)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_camel_case(&convertible_string), true)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_camel_case(&convertable_string), false)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_camel_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_camel_case(&convertable_string), false)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_camel_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_camel_case(&convertable_string), false)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_camel_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_camel_case(&convertable_string), false)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_camel_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_camel_case(&convertable_string), false)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_camel_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_camel_case(&convertable_string), false)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_camel_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_camel_case(&convertable_string), false)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_camel_case(&convertible_string), false)
     }
 }

--- a/src/case/class.rs
+++ b/src/case/class.rs
@@ -59,168 +59,168 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_class_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_table_case() {
-        let convertable_string: String = "foo_bars".to_owned();
+        let convertible_string: String = "foo_bars".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_case_with_loads_of_space() {
-        let convertable_string: String = "foo           bar".to_owned();
+        let convertible_string: String = "foo           bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn a_name_with_a_dot() {
-        let convertable_string: String = "Robert C. Martin".to_owned();
+        let convertible_string: String = "Robert C. Martin".to_owned();
         let expected: String = "RobertCMartin".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn random_text_with_bad_chars() {
-        let convertable_string: String = "Random text with *(bad) chars".to_owned();
+        let convertible_string: String = "Random text with *(bad) chars".to_owned();
         let expected: String = "RandomTextWithBadChar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn trailing_bad_chars() {
-        let convertable_string: String = "trailing bad_chars*(()())".to_owned();
+        let convertible_string: String = "trailing bad_chars*(()())".to_owned();
         let expected: String = "TrailingBadChar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn leading_bad_chars() {
-        let convertable_string: String = "-!#$%leading bad chars".to_owned();
+        let convertible_string: String = "-!#$%leading bad chars".to_owned();
         let expected: String = "LeadingBadChar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn wrapped_in_bad_chars() {
-        let convertable_string: String =
+        let convertible_string: String =
             "-!#$%wrapped in bad chars&*^*&(&*^&(<><?>><?><>))".to_owned();
         let expected: String = "WrappedInBadChar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn has_a_sign() {
-        let convertable_string: String = "has a + sign".to_owned();
+        let convertible_string: String = "has a + sign".to_owned();
         let expected: String = "HasASign".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_class_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_class_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), true)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_class_case(&convertible_string), true)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_class_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_class_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_class_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_class_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_class_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_class_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_table_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), true)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_class_case(&convertible_string), true)
     }
 }

--- a/src/case/kebab.rs
+++ b/src/case/kebab.rs
@@ -39,105 +39,105 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "foo-bar".to_owned();
-        assert_eq!(to_kebab_case(&convertable_string), expected)
+        assert_eq!(to_kebab_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "foo-bar".to_owned();
-        assert_eq!(to_kebab_case(&convertable_string), expected)
+        assert_eq!(to_kebab_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "foo-bar".to_owned();
-        assert_eq!(to_kebab_case(&convertable_string), expected)
+        assert_eq!(to_kebab_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "foo-bar".to_owned();
-        assert_eq!(to_kebab_case(&convertable_string), expected)
+        assert_eq!(to_kebab_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "foo-bar".to_owned();
-        assert_eq!(to_kebab_case(&convertable_string), expected)
+        assert_eq!(to_kebab_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "foo-bar".to_owned();
-        assert_eq!(to_kebab_case(&convertable_string), expected)
+        assert_eq!(to_kebab_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "foo-bar".to_owned();
-        assert_eq!(to_kebab_case(&convertable_string), expected)
+        assert_eq!(to_kebab_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "foo-bar".to_owned();
-        assert_eq!(to_kebab_case(&convertable_string), expected)
+        assert_eq!(to_kebab_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_kebab_case(&convertable_string), false)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_kebab_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_kebab_case(&convertable_string), false)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_kebab_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_kebab_case(&convertable_string), true)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_kebab_case(&convertible_string), true)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_kebab_case(&convertable_string), false)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_kebab_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_kebab_case(&convertable_string), false)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_kebab_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_kebab_case(&convertable_string), false)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_kebab_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_kebab_case(&convertable_string), false)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_kebab_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_kebab_case(&convertable_string), false)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_kebab_case(&convertible_string), false)
     }
 }

--- a/src/case/mod.rs
+++ b/src/case/mod.rs
@@ -72,10 +72,10 @@ pub struct CamelOptions {
 }
 
 #[doc(hidden)]
-pub fn to_case_snake_like(convertable_string: &str, replace_with: &str, case: &str) -> String {
+pub fn to_case_snake_like(convertible_string: &str, replace_with: &str, case: &str) -> String {
     let mut first_character: bool = true;
-    let mut result: String = String::with_capacity(convertable_string.len() * 2);
-    let chars: Vec<char> = trim_right(convertable_string).chars().collect();
+    let mut result: String = String::with_capacity(convertible_string.len() * 2);
+    let chars: Vec<char> = trim_right(convertible_string).chars().collect();
     for (index, &current_char) in chars.iter().enumerate() {
         if char_is_separator(&current_char) {
             if !first_character {
@@ -94,13 +94,13 @@ pub fn to_case_snake_like(convertable_string: &str, replace_with: &str, case: &s
 }
 
 #[doc(hidden)]
-pub fn to_case_camel_like(convertable_string: &str, camel_options: CamelOptions) -> String {
+pub fn to_case_camel_like(convertible_string: &str, camel_options: CamelOptions) -> String {
     let mut new_word: bool = camel_options.new_word;
     let mut first_word: bool = camel_options.first_word;
     let mut last_char: char = camel_options.last_char;
     let mut found_real_char: bool = false;
-    let mut result: String = String::with_capacity(convertable_string.len() * 2);
-    for character in trim_right(convertable_string).chars() {
+    let mut result: String = String::with_capacity(convertible_string.len() * 2);
+    for character in trim_right(convertible_string).chars() {
         if char_is_separator(&character) && found_real_char {
             new_word = true;
         } else if !found_real_char && is_not_alphanumeric(character) {
@@ -161,8 +161,8 @@ fn char_is_separator(character: &char) -> bool {
     is_not_alphanumeric(*character)
 }
 
-fn trim_right(convertable_string: &str) -> &str {
-    convertable_string.trim_end_matches(is_not_alphanumeric)
+fn trim_right(convertible_string: &str) -> &str {
+    convertible_string.trim_end_matches(is_not_alphanumeric)
 }
 
 fn is_not_alphanumeric(character: char) -> bool {

--- a/src/case/pascal.rs
+++ b/src/case/pascal.rs
@@ -53,155 +53,155 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_case_with_loads_of_space() {
-        let convertable_string: String = "foo           bar".to_owned();
+        let convertible_string: String = "foo           bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn a_name_with_a_dot() {
-        let convertable_string: String = "Robert C. Martin".to_owned();
+        let convertible_string: String = "Robert C. Martin".to_owned();
         let expected: String = "RobertCMartin".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn random_text_with_bad_chars() {
-        let convertable_string: String = "Random text with *(bad) chars".to_owned();
+        let convertible_string: String = "Random text with *(bad) chars".to_owned();
         let expected: String = "RandomTextWithBadChars".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn trailing_bad_chars() {
-        let convertable_string: String = "trailing bad_chars*(()())".to_owned();
+        let convertible_string: String = "trailing bad_chars*(()())".to_owned();
         let expected: String = "TrailingBadChars".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn leading_bad_chars() {
-        let convertable_string: String = "-!#$%leading bad chars".to_owned();
+        let convertible_string: String = "-!#$%leading bad chars".to_owned();
         let expected: String = "LeadingBadChars".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn wrapped_in_bad_chars() {
-        let convertable_string: String =
+        let convertible_string: String =
             "-!#$%wrapped in bad chars&*^*&(&*^&(<><?>><?><>))".to_owned();
         let expected: String = "WrappedInBadChars".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn has_a_sign() {
-        let convertable_string: String = "has a + sign".to_owned();
+        let convertible_string: String = "has a + sign".to_owned();
         let expected: String = "HasASign".to_owned();
-        assert_eq!(to_pascal_case(&convertable_string), expected)
+        assert_eq!(to_pascal_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_pascal_case(&convertable_string), false)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_pascal_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_pascal_case(&convertable_string), true)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_pascal_case(&convertible_string), true)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_pascal_case(&convertable_string), false)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_pascal_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_pascal_case(&convertable_string), false)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_pascal_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_pascal_case(&convertable_string), false)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_pascal_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_pascal_case(&convertable_string), false)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_pascal_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_pascal_case(&convertable_string), false)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_pascal_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_pascal_case(&convertable_string), false)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_pascal_case(&convertible_string), false)
     }
 }

--- a/src/case/screaming_snake.rs
+++ b/src/case/screaming_snake.rs
@@ -53,105 +53,105 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "FOO_BAR".to_owned();
-        assert_eq!(to_screaming_snake_case(&convertable_string), expected)
+        assert_eq!(to_screaming_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "FOO_BAR".to_owned();
-        assert_eq!(to_screaming_snake_case(&convertable_string), expected)
+        assert_eq!(to_screaming_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "FOO_BAR".to_owned();
-        assert_eq!(to_screaming_snake_case(&convertable_string), expected)
+        assert_eq!(to_screaming_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "FOO_BAR".to_owned();
-        assert_eq!(to_screaming_snake_case(&convertable_string), expected)
+        assert_eq!(to_screaming_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "FOO_BAR".to_owned();
-        assert_eq!(to_screaming_snake_case(&convertable_string), expected)
+        assert_eq!(to_screaming_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "FOO_BAR".to_owned();
-        assert_eq!(to_screaming_snake_case(&convertable_string), expected)
+        assert_eq!(to_screaming_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "FOO_BAR".to_owned();
-        assert_eq!(to_screaming_snake_case(&convertable_string), expected)
+        assert_eq!(to_screaming_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "FOO_BAR".to_owned();
-        assert_eq!(to_screaming_snake_case(&convertable_string), expected)
+        assert_eq!(to_screaming_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_screaming_snake_case(&convertable_string), false)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_screaming_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_screaming_snake_case(&convertable_string), false)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_screaming_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_screaming_snake_case(&convertable_string), false)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_screaming_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_screaming_snake_case(&convertable_string), false)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_screaming_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_screaming_snake_case(&convertable_string), false)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_screaming_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_screaming_snake_case(&convertable_string), false)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_screaming_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_screaming_snake_case(&convertable_string), true)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_screaming_snake_case(&convertible_string), true)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_screaming_snake_case(&convertable_string), false)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_screaming_snake_case(&convertible_string), false)
     }
 }

--- a/src/case/sentence.rs
+++ b/src/case/sentence.rs
@@ -57,155 +57,155 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "Foo bar".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "Foo bar".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "Foo bar".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "Foo bar".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "Foo bar".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "Foo bar".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "Foo bar".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "Foo bar".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_case_with_loads_of_space() {
-        let convertable_string: String = "foo           bar".to_owned();
+        let convertible_string: String = "foo           bar".to_owned();
         let expected: String = "Foo bar".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn a_name_with_a_dot() {
-        let convertable_string: String = "Robert C. Martin".to_owned();
+        let convertible_string: String = "Robert C. Martin".to_owned();
         let expected: String = "Robert c martin".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn random_text_with_bad_chars() {
-        let convertable_string: String = "Random text with *(bad) chars".to_owned();
+        let convertible_string: String = "Random text with *(bad) chars".to_owned();
         let expected: String = "Random text with bad chars".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn trailing_bad_chars() {
-        let convertable_string: String = "trailing bad_chars*(()())".to_owned();
+        let convertible_string: String = "trailing bad_chars*(()())".to_owned();
         let expected: String = "Trailing bad chars".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn leading_bad_chars() {
-        let convertable_string: String = "-!#$%leading bad chars".to_owned();
+        let convertible_string: String = "-!#$%leading bad chars".to_owned();
         let expected: String = "Leading bad chars".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn wrapped_in_bad_chars() {
-        let convertable_string: String =
+        let convertible_string: String =
             "-!#$%wrapped in bad chars&*^*&(&*^&(<><?>><?><>))".to_owned();
         let expected: String = "Wrapped in bad chars".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn has_a_sign() {
-        let convertable_string: String = "has a + sign".to_owned();
+        let convertible_string: String = "has a + sign".to_owned();
         let expected: String = "Has a sign".to_owned();
-        assert_eq!(to_sentence_case(&convertable_string), expected)
+        assert_eq!(to_sentence_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_sentence_case(&convertable_string), false)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_sentence_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_sentence_case(&convertable_string), false)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_sentence_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_sentence_case(&convertable_string), false)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_sentence_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_sentence_case(&convertable_string), true)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_sentence_case(&convertible_string), true)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_sentence_case(&convertable_string), false)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_sentence_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_sentence_case(&convertable_string), false)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_sentence_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_sentence_case(&convertable_string), false)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_sentence_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_sentence_case(&convertable_string), false)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_sentence_case(&convertible_string), false)
     }
 }

--- a/src/case/snake.rs
+++ b/src/case/snake.rs
@@ -44,155 +44,155 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "foo_bar".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "foo_bar".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "foo_bar".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "foo_bar".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "foo_bar".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "foo_bar".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "foo_bar".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "foo_bar".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_case_with_loads_of_space() {
-        let convertable_string: String = "foo           bar".to_owned();
+        let convertible_string: String = "foo           bar".to_owned();
         let expected: String = "foo_bar".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn a_name_with_a_dot() {
-        let convertable_string: String = "Robert C. Martin".to_owned();
+        let convertible_string: String = "Robert C. Martin".to_owned();
         let expected: String = "robert_c_martin".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn random_text_with_bad_chars() {
-        let convertable_string: String = "Random text with *(bad) chars".to_owned();
+        let convertible_string: String = "Random text with *(bad) chars".to_owned();
         let expected: String = "random_text_with_bad_chars".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn trailing_bad_chars() {
-        let convertable_string: String = "trailing bad_chars*(()())".to_owned();
+        let convertible_string: String = "trailing bad_chars*(()())".to_owned();
         let expected: String = "trailing_bad_chars".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn leading_bad_chars() {
-        let convertable_string: String = "-!#$%leading bad chars".to_owned();
+        let convertible_string: String = "-!#$%leading bad chars".to_owned();
         let expected: String = "leading_bad_chars".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn wrapped_in_bad_chars() {
-        let convertable_string: String =
+        let convertible_string: String =
             "-!#$%wrapped in bad chars&*^*&(&*^&(<><?>><?><>))".to_owned();
         let expected: String = "wrapped_in_bad_chars".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn has_a_sign() {
-        let convertable_string: String = "has a + sign".to_owned();
+        let convertible_string: String = "has a + sign".to_owned();
         let expected: String = "has_a_sign".to_owned();
-        assert_eq!(to_snake_case(&convertable_string), expected)
+        assert_eq!(to_snake_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_snake_case(&convertable_string), false)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_snake_case(&convertable_string), false)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_snake_case(&convertable_string), false)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_snake_case(&convertable_string), false)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_snake_case(&convertable_string), false)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_snake_case(&convertable_string), false)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_snake_case(&convertable_string), false)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_snake_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_snake_case(&convertable_string), true)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_snake_case(&convertible_string), true)
     }
 }

--- a/src/case/table.rs
+++ b/src/case/table.rs
@@ -43,118 +43,118 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "foo_bars".to_owned();
-        assert_eq!(to_table_case(&convertable_string), expected)
+        assert_eq!(to_table_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "foo_bars".to_owned();
-        assert_eq!(to_table_case(&convertable_string), expected)
+        assert_eq!(to_table_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "foo_bars".to_owned();
-        assert_eq!(to_table_case(&convertable_string), expected)
+        assert_eq!(to_table_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "foo_bars".to_owned();
-        assert_eq!(to_table_case(&convertable_string), expected)
+        assert_eq!(to_table_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "foo_bars".to_owned();
-        assert_eq!(to_table_case(&convertable_string), expected)
+        assert_eq!(to_table_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "foo_bars".to_owned();
-        assert_eq!(to_table_case(&convertable_string), expected)
+        assert_eq!(to_table_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "foo_bars".to_owned();
-        assert_eq!(to_table_case(&convertable_string), expected)
+        assert_eq!(to_table_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "foo_bars".to_owned();
-        assert_eq!(to_table_case(&convertable_string), expected)
+        assert_eq!(to_table_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_table_case() {
-        let convertable_string: String = "foo_bars".to_owned();
+        let convertible_string: String = "foo_bars".to_owned();
         let expected: String = "foo_bars".to_owned();
-        assert_eq!(to_table_case(&convertable_string), expected)
+        assert_eq!(to_table_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_table_case(&convertable_string), false)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_table_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_table_case(&convertable_string), false)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_table_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_table_case(&convertable_string), false)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_table_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_table_case(&convertable_string), false)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_table_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_table_case(&convertable_string), false)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_table_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_table_case(&convertable_string), false)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_table_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_table_case(&convertable_string), false)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_table_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_table_case(&convertable_string), false)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_table_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_table_case() {
-        let convertable_string: String = "foo_bars".to_owned();
-        assert_eq!(is_table_case(&convertable_string), true)
+        let convertible_string: String = "foo_bars".to_owned();
+        assert_eq!(is_table_case(&convertible_string), true)
     }
 }

--- a/src/case/title.rs
+++ b/src/case/title.rs
@@ -48,155 +48,155 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "Foo Bar".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "Foo Bar".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "Foo Bar".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "Foo Bar".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "Foo Bar".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "Foo Bar".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "Foo Bar".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "Foo Bar".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_case_with_loads_of_space() {
-        let convertable_string: String = "foo           bar".to_owned();
+        let convertible_string: String = "foo           bar".to_owned();
         let expected: String = "Foo Bar".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn a_name_with_a_dot() {
-        let convertable_string: String = "Robert C. Martin".to_owned();
+        let convertible_string: String = "Robert C. Martin".to_owned();
         let expected: String = "Robert C Martin".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn random_text_with_bad_chars() {
-        let convertable_string: String = "Random text with *(bad) chars".to_owned();
+        let convertible_string: String = "Random text with *(bad) chars".to_owned();
         let expected: String = "Random Text With Bad Chars".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn trailing_bad_chars() {
-        let convertable_string: String = "trailing bad_chars*(()())".to_owned();
+        let convertible_string: String = "trailing bad_chars*(()())".to_owned();
         let expected: String = "Trailing Bad Chars".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn leading_bad_chars() {
-        let convertable_string: String = "-!#$%leading bad chars".to_owned();
+        let convertible_string: String = "-!#$%leading bad chars".to_owned();
         let expected: String = "Leading Bad Chars".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn wrapped_in_bad_chars() {
-        let convertable_string: String =
+        let convertible_string: String =
             "-!#$%wrapped in bad chars&*^*&(&*^&(<><?>><?><>))".to_owned();
         let expected: String = "Wrapped In Bad Chars".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn has_a_sign() {
-        let convertable_string: String = "has a + sign".to_owned();
+        let convertible_string: String = "has a + sign".to_owned();
         let expected: String = "Has A Sign".to_owned();
-        assert_eq!(to_title_case(&convertable_string), expected)
+        assert_eq!(to_title_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_title_case(&convertable_string), false)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_title_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_title_case(&convertable_string), false)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_title_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_title_case(&convertable_string), false)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_title_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_title_case(&convertable_string), false)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_title_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_title_case(&convertable_string), true)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_title_case(&convertible_string), true)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_title_case(&convertable_string), false)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_title_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_title_case(&convertable_string), false)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_title_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_title_case(&convertable_string), false)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_title_case(&convertible_string), false)
     }
 }

--- a/src/case/train.rs
+++ b/src/case/train.rs
@@ -48,155 +48,155 @@ mod tests {
 
     #[test]
     fn from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
+        let convertible_string: String = "fooBar".to_owned();
         let expected: String = "Foo-Bar".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
+        let convertible_string: String = "FooBar".to_owned();
         let expected: String = "Foo-Bar".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
+        let convertible_string: String = "foo-bar".to_owned();
         let expected: String = "Foo-Bar".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
+        let convertible_string: String = "Foo bar".to_owned();
         let expected: String = "Foo-Bar".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
+        let convertible_string: String = "Foo Bar".to_owned();
         let expected: String = "Foo-Bar".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
+        let convertible_string: String = "Foo-Bar".to_owned();
         let expected: String = "Foo-Bar".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
+        let convertible_string: String = "FOO_BAR".to_owned();
         let expected: String = "Foo-Bar".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
+        let convertible_string: String = "foo_bar".to_owned();
         let expected: String = "Foo-Bar".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn from_case_with_loads_of_space() {
-        let convertable_string: String = "foo           bar".to_owned();
+        let convertible_string: String = "foo           bar".to_owned();
         let expected: String = "Foo-Bar".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn a_name_with_a_dot() {
-        let convertable_string: String = "Robert C. Martin".to_owned();
+        let convertible_string: String = "Robert C. Martin".to_owned();
         let expected: String = "Robert-C-Martin".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn random_text_with_bad_chars() {
-        let convertable_string: String = "Random text with *(bad) chars".to_owned();
+        let convertible_string: String = "Random text with *(bad) chars".to_owned();
         let expected: String = "Random-Text-With-Bad-Chars".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn trailing_bad_chars() {
-        let convertable_string: String = "trailing bad_chars*(()())".to_owned();
+        let convertible_string: String = "trailing bad_chars*(()())".to_owned();
         let expected: String = "Trailing-Bad-Chars".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn leading_bad_chars() {
-        let convertable_string: String = "-!#$%leading bad chars".to_owned();
+        let convertible_string: String = "-!#$%leading bad chars".to_owned();
         let expected: String = "Leading-Bad-Chars".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn wrapped_in_bad_chars() {
-        let convertable_string: String =
+        let convertible_string: String =
             "-!#$%wrapped in bad chars&*^*&(&*^&(<><?>><?><>))".to_owned();
         let expected: String = "Wrapped-In-Bad-Chars".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn has_a_sign() {
-        let convertable_string: String = "has a + sign".to_owned();
+        let convertible_string: String = "has a + sign".to_owned();
         let expected: String = "Has-A-Sign".to_owned();
-        assert_eq!(to_train_case(&convertable_string), expected)
+        assert_eq!(to_train_case(&convertible_string), expected)
     }
 
     #[test]
     fn is_correct_from_camel_case() {
-        let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_train_case(&convertable_string), false)
+        let convertible_string: String = "fooBar".to_owned();
+        assert_eq!(is_train_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
-        let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_train_case(&convertable_string), false)
+        let convertible_string: String = "FooBar".to_owned();
+        assert_eq!(is_train_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
-        let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_train_case(&convertable_string), false)
+        let convertible_string: String = "foo-bar".to_owned();
+        assert_eq!(is_train_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
-        let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_train_case(&convertable_string), false)
+        let convertible_string: String = "Foo bar".to_owned();
+        assert_eq!(is_train_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
-        let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_train_case(&convertable_string), false)
+        let convertible_string: String = "Foo Bar".to_owned();
+        assert_eq!(is_train_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
-        let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_train_case(&convertable_string), true)
+        let convertible_string: String = "Foo-Bar".to_owned();
+        assert_eq!(is_train_case(&convertible_string), true)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
-        let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_train_case(&convertable_string), false)
+        let convertible_string: String = "FOO_BAR".to_owned();
+        assert_eq!(is_train_case(&convertible_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
-        let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_train_case(&convertable_string), false)
+        let convertible_string: String = "foo_bar".to_owned();
+        assert_eq!(is_train_case(&convertible_string), false)
     }
 }

--- a/src/string/pluralize.rs
+++ b/src/string/pluralize.rs
@@ -166,11 +166,17 @@ mod tests {
 
     #[test]
     fn pluralize_kebab_case() {
-        assert_eq!("section-difficulties", super::to_plural("section-difficulty"));
+        assert_eq!(
+            "section-difficulties",
+            super::to_plural("section-difficulty")
+        );
     }
 
     #[test]
     fn pluralize_snake_case_compound() {
-        assert_eq!("section_difficulties", super::to_plural("section_difficulty"));
+        assert_eq!(
+            "section_difficulties",
+            super::to_plural("section_difficulty")
+        );
     }
 }

--- a/typos.toml
+++ b/typos.toml
@@ -13,6 +13,10 @@ AttributeIDSupressMenu = "AttributeIDSupressMenu"
 teh = "teh"
 Hashi = "Hashi"
 consts = "consts"
+# Ordinal suffix and regex pattern fragments
+nd = "nd"
+strat = "strat"
+extrem = "extrem"
 
 [files]
 extend-exclude = ["**/*.js", "**/*.css", "**/*.html", "examples/*/static/**/*.*"]


### PR DESCRIPTION
## Summary
- Rename `convertable_string` to `convertible_string` across all case modules
- Add false positive words (`nd`, `strat`, `extrem`) to typos.toml
- Switch CI fmt workflow from nightly to stable toolchain